### PR TITLE
feat(SalesChannel): Add Sales Channel and Shipping Profile

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { resolve } from 'path'
 import { MigrationModule } from './modules/migration/migration.module'
 import { OrderModule } from './modules/order/order.module'
 import { ProductModule } from './modules/product/product.module'
+import { SalesChannelModule } from './modules/sales-channel/sales-channel.module'
 import { StoreModule } from './modules/store/store.module'
 import { UserModule } from './modules/user/user.module'
 
@@ -13,11 +14,12 @@ async function bootstrap() {
   const expressInstance = express()
 
   await new Medusa(resolve(__dirname, '..'), expressInstance).load([
+    MigrationModule,
     OrderModule,
     ProductModule,
+    SalesChannelModule,
     StoreModule,
     UserModule,
-    MigrationModule,
   ])
 
   expressInstance.listen(config.serverConfig.port, () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import express = require('express')
 const config = require('../medusa-config')
 import { Medusa } from 'medusa-extender'
 import { resolve } from 'path'
+import { InviteModule } from './modules/invite/invite.module'
 import { MigrationModule } from './modules/migration/migration.module'
 import { OrderModule } from './modules/order/order.module'
 import { ProductModule } from './modules/product/product.module'
@@ -14,6 +15,7 @@ async function bootstrap() {
   const expressInstance = express()
 
   await new Medusa(resolve(__dirname, '..'), expressInstance).load([
+    InviteModule,
     MigrationModule,
     OrderModule,
     ProductModule,

--- a/src/modules/invite/invite.entity.ts
+++ b/src/modules/invite/invite.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm'
+
+import { Entity as MedusaEntity } from 'medusa-extender'
+import { Invite as MedusaInvite } from '@medusajs/medusa'
+import { Store } from '../store/store.entity'
+
+@MedusaEntity({ override: MedusaInvite })
+@Entity()
+export class Invite extends MedusaInvite {
+  @Index()
+  @Column({ nullable: true })
+  store_id: string
+
+  @ManyToOne(() => Store, (store) => store.invites)
+  @JoinColumn({ name: 'store_id' })
+  store: Store
+}

--- a/src/modules/invite/invite.module.ts
+++ b/src/modules/invite/invite.module.ts
@@ -1,0 +1,14 @@
+import { Module } from 'medusa-extender'
+import { Invite } from './invite.entity'
+import InviteRepository from './invite.repository'
+import { InviteService } from './invite.service'
+import { AttachInviteSubscriberMiddleware } from './inviteSubscriber.middleware'
+@Module({
+  imports: [
+    Invite,
+    InviteRepository,
+    InviteService,
+    AttachInviteSubscriberMiddleware,
+  ],
+})
+export class InviteModule {}

--- a/src/modules/invite/invite.repository.ts
+++ b/src/modules/invite/invite.repository.ts
@@ -1,0 +1,12 @@
+import { Repository as MedusaRepository, Utils } from 'medusa-extender'
+
+import { EntityRepository } from 'typeorm'
+import { InviteRepository as MedusaInviteRepository } from '@medusajs/medusa/dist/repositories/invite'
+import { Invite } from './invite.entity'
+
+@MedusaRepository({ override: MedusaInviteRepository })
+@EntityRepository(Invite)
+export default class InviteRepository extends Utils.repositoryMixin<
+  Invite,
+  MedusaInviteRepository
+>(MedusaInviteRepository) {}

--- a/src/modules/invite/invite.service.ts
+++ b/src/modules/invite/invite.service.ts
@@ -1,0 +1,71 @@
+import { EntityManager } from 'typeorm'
+import { Service } from 'medusa-extender'
+import { buildQuery, EventBusService } from '@medusajs/medusa'
+import { ConfigModule } from '@medusajs/medusa/dist/types/global'
+import { default as MedusaInviteService } from '@medusajs/medusa/dist/services/invite'
+import { Invite } from './invite.entity'
+import InviteRepository from './invite.repository'
+import { User } from '../user/user.entity'
+import UserRepository from '../user/user.repository'
+import UserService from '../user/user.service'
+import { FindConfig, QuerySelector } from '@medusajs/medusa/dist/types/common'
+
+type InjectedDependencies = {
+  manager: EntityManager
+  userService: UserService
+  userRepository: typeof UserRepository
+  eventBusService: EventBusService
+  inviteRepository: typeof InviteRepository
+  loggedInUser?: User
+}
+
+type ListInvite = Omit<Invite, 'beforeInsert'> & {
+  token: string
+}
+
+@Service({ scope: 'SCOPED', override: MedusaInviteService })
+export class InviteService extends MedusaInviteService {
+  static readonly resolutionKey = 'inviteService'
+
+  private readonly manager: EntityManager
+  private readonly container: InjectedDependencies
+  private readonly inviteRepository: typeof InviteRepository
+
+  constructor(container: InjectedDependencies, configModule: ConfigModule) {
+    super(container, configModule)
+
+    this.manager = container.manager
+    this.container = container
+    this.inviteRepository = container.inviteRepository
+  }
+
+  async list(
+    selector: QuerySelector<Invite>,
+    config: FindConfig<Invite> = {}
+  ): Promise<ListInvite[]> {
+    if (
+      Object.keys(this.container).includes('loggedInUser') &&
+      this.container.loggedInUser.store_id
+    ) {
+      selector['store_id'] = this.container.loggedInUser.store_id
+    }
+
+    return super.list(selector, config as any) as unknown as Promise<
+      ListInvite[]
+    >
+  }
+
+  async retrieve(
+    inviteId: string,
+    config: FindConfig<Invite> = {}
+  ): Promise<Invite | null> {
+    return await this.atomicPhase_(async (m) => {
+      const inviteRepo: InviteRepository = m.getCustomRepository(
+        this.inviteRepository
+      )
+
+      const query = buildQuery({ id: inviteId }, config)
+      return await inviteRepo.findOne(query)
+    })
+  }
+}

--- a/src/modules/invite/invite.subscriber.ts
+++ b/src/modules/invite/invite.subscriber.ts
@@ -1,0 +1,36 @@
+import {
+  Connection,
+  EntitySubscriberInterface,
+  EventSubscriber,
+  InsertEvent,
+} from 'typeorm'
+import {
+  Utils as MedusaUtils,
+  OnMedusaEntityEvent,
+  eventEmitter,
+} from 'medusa-extender'
+
+import { Invite } from './invite.entity'
+
+@EventSubscriber()
+export default class InviteSubscriber
+  implements EntitySubscriberInterface<Invite>
+{
+  static attachTo(connection: Connection): void {
+    MedusaUtils.attachOrReplaceEntitySubscriber(connection, InviteSubscriber)
+  }
+
+  public listenTo(): typeof Invite {
+    return Invite
+  }
+
+  public async beforeInsert(event: InsertEvent<Invite>): Promise<void> {
+    return await eventEmitter.emitAsync(
+      OnMedusaEntityEvent.Before.InsertEvent(Invite),
+      {
+        event,
+        transactionalEntityManager: event.manager,
+      }
+    )
+  }
+}

--- a/src/modules/invite/inviteAccept.controller.ts
+++ b/src/modules/invite/inviteAccept.controller.ts
@@ -1,0 +1,46 @@
+import { AdminPostInvitesInviteAcceptReq } from '@medusajs/medusa'
+import { EntityManager } from 'typeorm'
+import { InviteService } from './invite.service'
+import { MedusaError } from 'medusa-core-utils'
+import UserService from '../user/user.service'
+import { validator } from '@medusajs/medusa/dist/utils/validator'
+
+export default async (req, res) => {
+  const validated = await validator(AdminPostInvitesInviteAcceptReq, req.body)
+
+  const inviteService: InviteService = req.scope.resolve(
+    InviteService.resolutionKey
+  )
+
+  const manager: EntityManager = req.scope.resolve('manager')
+
+  await manager.transaction(async (m) => {
+    // retrieve invite
+    let decoded
+    try {
+      decoded = inviteService.withTransaction(m).verifyToken(validated.token)
+    } catch (err) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        'Token is not valid'
+      )
+    }
+
+    const invite = await inviteService
+      .withTransaction(m)
+      .retrieve(decoded.invite_id)
+
+    const store_id = invite ? invite.store_id : null
+
+    const user = await inviteService
+      .withTransaction(m)
+      .accept(validated.token, validated.user)
+
+    if (store_id) {
+      const userService: UserService = req.scope.resolve('userService')
+      await userService.withTransaction(m).addUserToStore(user.id, store_id)
+    }
+
+    res.sendStatus(200)
+  })
+}

--- a/src/modules/invite/inviteSubscriber.middleware.ts
+++ b/src/modules/invite/inviteSubscriber.middleware.ts
@@ -1,0 +1,28 @@
+import {
+  MEDUSA_RESOLVER_KEYS,
+  MedusaAuthenticatedRequest,
+  MedusaMiddleware,
+  Middleware,
+} from 'medusa-extender'
+import { NextFunction, Response } from 'express'
+
+import { Connection } from 'typeorm'
+import InviteSubscriber from './invite.subscriber'
+
+@Middleware({
+  requireAuth: true,
+  routes: [{ method: 'post', path: '/admin/invites*' }],
+})
+export class AttachInviteSubscriberMiddleware implements MedusaMiddleware {
+  public async consume(
+    req: MedusaAuthenticatedRequest,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    const { connection } = req.scope.resolve(MEDUSA_RESOLVER_KEYS.manager) as {
+      connection: Connection
+    }
+    InviteSubscriber.attachTo(connection)
+    return next()
+  }
+}

--- a/src/modules/migrations/1670645201506-InitialMigration.ts
+++ b/src/modules/migrations/1670645201506-InitialMigration.ts
@@ -52,11 +52,26 @@ export default class InitialMigration1670645201506
       `CREATE INDEX "IDX_sales_channel_store_id" ON "sales_channel" ("store_id")`
     )
     await queryRunner.query(
-      `ALTER TABLE "sales_channel" ADD CONSTRAINT "FK_sales_channel_store_id" FOREIGN KEY ("store_id") REFERENCES ON DELETE NO ACTION ON UPDATE NO ACTION`
+      `ALTER TABLE "sales_channel" ADD CONSTRAINT "FK_sales_channel_store_id" FOREIGN KEY ("store_id") REFERENCES "store"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    )
+
+    await queryRunner.query(
+      `ALTER TABLE "invite" ADD "store_id" character varying`
+    )
+    await queryRunner.query(
+      `CREATE INDEX "IDX_invite_store_id" ON "invite" ("store_id")`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "invite" ADD CONSTRAINT "FK_invite_store_id" FOREIGN KEY ("store_id") REFERENCES "store"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
     )
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "invite" DROP CONSTRAINT "FK_invite_store_id"`
+    )
+    await queryRunner.query(`DROP INDEX "public"."IDX_invite_store_id"`)
+    await queryRunner.query(`ALTER TABLE "invite" DROP COLUMN "store_id"`)
     await queryRunner.query(
       `ALTER TABLE "sales_channel" DROP CONSTRAINT "FK_sales_channel_store_id"`
     )

--- a/src/modules/migrations/1670645201506-InitialMigration.ts
+++ b/src/modules/migrations/1670645201506-InitialMigration.ts
@@ -39,14 +39,31 @@ export default class InitialMigration1670645201506
       `ALTER TABLE "product" ADD "store_id" character varying NOT NULL`
     )
     await queryRunner.query(
-      `CREATE INDEX "IDX_product_store_id" ON "order" (store_id)`
+      `CREATE INDEX "IDX_product_store_id" ON "product" ("store_id")`
     )
     await queryRunner.query(
       `ALTER TABLE "product" ADD CONSTRAINT "FK_product_store_id" FOREIGN KEY ("store_id") REFERENCES "store"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
     )
+
+    await queryRunner.query(
+      `ALTER TABLE "sales_channel" ADD "store_id" character varying`
+    )
+    await queryRunner.query(
+      `CREATE INDEX "IDX_sales_channel_store_id" ON "sales_channel" ("store_id")`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "sales_channel" ADD CONSTRAINT "FK_sales_channel_store_id" FOREIGN KEY ("store_id") REFERENCES ON DELETE NO ACTION ON UPDATE NO ACTION`
+    )
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "sales_channel" DROP CONSTRAINT "FK_sales_channel_store_id"`
+    )
+    await queryRunner.query(`DROP INDEX "public"."IDX_sales_channel_store_id"`)
+    await queryRunner.query(
+      `ALTER TABLE "sales_channel" DROP COLUMN "store_id"`
+    )
     await queryRunner.query(
       `ALTER TABLE "product" DROP CONSTRAINT "FK_product_store_id"`
     )

--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -56,6 +56,10 @@ export class OrderService extends MedusaOrderService {
       this.container.loggedInUser.store_id
     ) {
       selector['store_id'] = this.container.loggedInUser.store_id
+      config.relations = config.relations || []
+      config.relations.push('children')
+      config.relations.push('parent')
+      config.relations.push('store')
     }
 
     return super.listAndCount(selector, config as any) as unknown as Promise<

--- a/src/modules/product/product.service.ts
+++ b/src/modules/product/product.service.ts
@@ -67,7 +67,8 @@ export class ProductService extends MedusaProductService {
       selector['store_id'] = this.container.loggedInUser.store_id
     }
 
-    ;(config.select as any) = config.select?.push('store_id') || ['store_id']
+    config.select = config.select || []
+    config.select.push('store_id')
 
     return super.prepareListQuery_(selector, config as any)
   }

--- a/src/modules/sales-channel/sales-channel.entity.ts
+++ b/src/modules/sales-channel/sales-channel.entity.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm'
+import { Entity as MedusaEntity } from 'medusa-extender'
+import { SalesChannel as MedusaSalesChannel } from '@medusajs/medusa'
+import { Store } from '../store/store.entity'
+
+@MedusaEntity({ override: MedusaSalesChannel })
+@Entity()
+export class SalesChannel extends MedusaSalesChannel {
+  @Index()
+  @Column({ nullable: true })
+  store_id: string
+
+  @ManyToOne(() => Store, (store) => store.members)
+  @JoinColumn({ name: 'store_id', referencedColumnName: 'id' })
+  store: Store
+}

--- a/src/modules/sales-channel/sales-channel.module.ts
+++ b/src/modules/sales-channel/sales-channel.module.ts
@@ -1,0 +1,9 @@
+import { Module } from 'medusa-extender'
+import { SalesChannel } from './sales-channel.entity'
+import SalesChannelRepository from './sales-channel.repository'
+import SalesChannelService from './sales-channel.service'
+
+@Module({
+  imports: [SalesChannel, SalesChannelRepository, SalesChannelService],
+})
+export class SalesChannelModule {}

--- a/src/modules/sales-channel/sales-channel.repository.ts
+++ b/src/modules/sales-channel/sales-channel.repository.ts
@@ -1,0 +1,11 @@
+import { Repository as MedusaRepository, Utils } from 'medusa-extender'
+import { EntityRepository } from 'typeorm'
+import { SalesChannelRepository as MedusaSalesChannelRepository } from '@medusajs/medusa/dist/repositories/sales-channel'
+import { SalesChannel } from './sales-channel.entity'
+
+@MedusaRepository({ override: MedusaSalesChannelRepository })
+@EntityRepository(SalesChannel)
+export default class SalesChannelRepository extends Utils.repositoryMixin<
+  SalesChannel,
+  MedusaSalesChannelRepository
+>(MedusaSalesChannelRepository) {}

--- a/src/modules/sales-channel/sales-channel.service.ts
+++ b/src/modules/sales-channel/sales-channel.service.ts
@@ -1,0 +1,28 @@
+import { Service } from 'medusa-extender'
+import { EntityManager } from 'typeorm'
+
+import { SalesChannelService as MedusaSalesChannelService } from '@medusajs/medusa/dist/services'
+import { User } from '../user/user.entity'
+import SalesChannelRepository from './sales-channel.repository'
+import StoreService from '../store/store.service'
+import { EventBusService } from '@medusajs/medusa'
+
+type ConstructorParams = {
+  salesChannelRepository: typeof SalesChannelRepository
+  eventBusService: EventBusService
+  manager: EntityManager
+  storeService: StoreService
+  loggedInUser?: User
+}
+
+@Service({ override: MedusaSalesChannelService, scope: 'SCOPED' })
+export default class SalesChannelService extends MedusaSalesChannelService {
+  private readonly manager: EntityManager
+  private readonly salesChannelRepository: typeof SalesChannelRepository
+
+  constructor(private readonly container: ConstructorParams) {
+    super(container)
+    this.manager = container.manager
+    this.salesChannelRepository = container.salesChannelRepository
+  }
+}

--- a/src/modules/sales-channel/sales-channel.service.ts
+++ b/src/modules/sales-channel/sales-channel.service.ts
@@ -1,11 +1,21 @@
-import { Service } from 'medusa-extender'
+import {
+  Service,
+  OnMedusaEntityEvent,
+  MedusaEventHandlerParams,
+  EntityEventType,
+} from 'medusa-extender'
 import { EntityManager } from 'typeorm'
+import { MedusaError } from 'medusa-core-utils'
 
 import { SalesChannelService as MedusaSalesChannelService } from '@medusajs/medusa/dist/services'
 import { User } from '../user/user.entity'
 import SalesChannelRepository from './sales-channel.repository'
 import StoreService from '../store/store.service'
 import { EventBusService } from '@medusajs/medusa'
+import { SalesChannel } from './sales-channel.entity'
+import SalesChannelSubscriber from './sales-channel.subscriber'
+import { CreateSalesChannelInput } from '@medusajs/medusa/dist/types/sales-channels'
+import { QuerySelector, FindConfig } from '@medusajs/medusa/dist/types/common'
 
 type ConstructorParams = {
   salesChannelRepository: typeof SalesChannelRepository
@@ -19,10 +29,102 @@ type ConstructorParams = {
 export default class SalesChannelService extends MedusaSalesChannelService {
   private readonly manager: EntityManager
   private readonly salesChannelRepository: typeof SalesChannelRepository
+  private readonly storeService: StoreService
 
   constructor(private readonly container: ConstructorParams) {
     super(container)
     this.manager = container.manager
+    this.storeService = container.storeService
     this.salesChannelRepository = container.salesChannelRepository
+
+    SalesChannelSubscriber.attachTo(this.manager.connection)
+  }
+
+  // Retrieve store_id and set it on the New Sales Channel
+  @OnMedusaEntityEvent.Before.Insert(SalesChannel, { async: true })
+  public async addStoreIdToNewSalesChannel(
+    params: MedusaEventHandlerParams<SalesChannel, 'Insert'>
+  ): Promise<EntityEventType<SalesChannel, 'Insert'>> {
+    const { event } = params
+
+    if (event.entity.store_id) {
+      return event
+    }
+
+    const store = await this.storeService
+      .withTransaction(event.manager)
+      .retrieve({
+        relations: ['default_sales_channel'],
+      })
+
+    if (store) {
+      event.entity.store_id = store.id
+
+      if (!store.default_sales_channel_id) {
+        await this.storeService.withTransaction(event.manager).update({
+          default_sales_channel_id: event.entity.id,
+        })
+      }
+    } else {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        'Store does not exist for new Sales Channel'
+      )
+    }
+
+    return params.event
+  }
+
+  async create(
+    data: CreateSalesChannelInput & { store_id?: string }
+  ): Promise<SalesChannel | never> {
+    return super.create(data) as Promise<SalesChannel | never>
+  }
+
+  /**
+   * Creates a default sales channel, if this does not already exist.
+   * @return the sales channel
+   */
+  async createDefault(): Promise<SalesChannel> {
+    return this.atomicPhase_(async (transactionManager) => {
+      const store = await this.storeService
+        .withTransaction(transactionManager)
+        .retrieve({
+          relations: ['default_sales_channel'],
+        })
+
+      if (store.default_sales_channel_id) {
+        return store.default_sales_channel
+      }
+
+      const defaultSalesChannel = await this.create({
+        description: 'Created by Renlo',
+        name: 'Default Sales Channel',
+        is_disabled: false,
+        store_id: store.id, // Add store_id to create
+      })
+
+      await this.storeService.withTransaction(transactionManager).update({
+        default_sales_channel_id: defaultSalesChannel.id,
+      })
+
+      return defaultSalesChannel as SalesChannel
+    }) as Promise<SalesChannel>
+  }
+
+  async listAndCount(
+    selector: QuerySelector<SalesChannel>,
+    config?: FindConfig<SalesChannel>
+  ): Promise<[SalesChannel[], number]> {
+    if (
+      Object.keys(this.container).includes('loggedInUser') &&
+      this.container.loggedInUser.store_id
+    ) {
+      selector['store_id'] = this.container.loggedInUser.store_id
+    }
+
+    return super.listAndCount(selector, config as any) as unknown as Promise<
+      [SalesChannel[], number]
+    >
   }
 }

--- a/src/modules/sales-channel/sales-channel.subscriber.ts
+++ b/src/modules/sales-channel/sales-channel.subscriber.ts
@@ -1,0 +1,43 @@
+import {
+  Connection,
+  EntitySubscriberInterface,
+  EventSubscriber,
+  InsertEvent,
+} from 'typeorm'
+import {
+  Utils as MedusaUtils,
+  OnMedusaEntityEvent,
+  eventEmitter,
+} from 'medusa-extender'
+
+import { SalesChannel } from './sales-channel.entity'
+
+@EventSubscriber()
+export default class SalesChannelSubscriber
+  implements EntitySubscriberInterface<SalesChannel>
+{
+  static attachTo(connection: Connection): void {
+    MedusaUtils.attachOrReplaceEntitySubscriber(
+      connection,
+      SalesChannelSubscriber
+    )
+  }
+
+  public listenTo(): typeof SalesChannel {
+    return SalesChannel
+  }
+
+  /**
+   * Relay the event to the handlers.
+   * @param event Event to pass to the event handler
+   */
+  public async beforeInsert(event: InsertEvent<SalesChannel>): Promise<void> {
+    return await eventEmitter.emitAsync(
+      OnMedusaEntityEvent.Before.InsertEvent(SalesChannel),
+      {
+        event,
+        transactionalEntityManager: event.manager,
+      }
+    )
+  }
+}

--- a/src/modules/store/store.entity.ts
+++ b/src/modules/store/store.entity.ts
@@ -8,15 +8,12 @@ import { Product } from '../product/product.entity'
 @MedusaEntity({ override: MedusaStore })
 @Entity()
 export class Store extends MedusaStore {
-  @OneToMany(() => User, (user) => user.store_id)
-  @JoinColumn({ name: 'id', referencedColumnName: 'store_id' })
+  @OneToMany(() => User, (user) => user.store)
   members: User[]
 
-  @OneToMany(() => Product, (product) => product.store_id)
-  @JoinColumn({ name: 'id', referencedColumnName: 'store_id' })
+  @OneToMany(() => Product, (product) => product.store)
   products: Product[]
 
-  @OneToMany(() => Order, (order) => order.store_id)
-  @JoinColumn({ name: 'id', referencedColumnName: 'store_id' })
+  @OneToMany(() => Order, (order) => order.store)
   orders: Order[]
 }

--- a/src/modules/store/store.entity.ts
+++ b/src/modules/store/store.entity.ts
@@ -4,6 +4,7 @@ import { Store as MedusaStore } from '@medusajs/medusa/dist'
 import { User } from '../user/user.entity'
 import { Order } from '../order/order.entity'
 import { Product } from '../product/product.entity'
+import { Invite } from '../invite/invite.entity'
 
 @MedusaEntity({ override: MedusaStore })
 @Entity()
@@ -16,4 +17,7 @@ export class Store extends MedusaStore {
 
   @OneToMany(() => Order, (order) => order.store)
   orders: Order[]
+
+  @OneToMany(() => Invite, (invite) => invite.store)
+  invites: Invite[]
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,11 +1,11 @@
 import { EntityManager } from 'typeorm'
+import { Service } from 'medusa-extender'
 import EventBusService from '@medusajs/medusa/dist/services/event-bus'
 import { FindConfig } from '@medusajs/medusa/dist/types/common'
 import {
   AnalyticsConfigService,
   UserService as MedusaUserService,
 } from '@medusajs/medusa/dist/services'
-import { Service } from 'medusa-extender'
 import { User } from './user.entity'
 import UserRepository from './user.repository'
 import { FlagRouter } from '@medusajs/medusa/dist/utils/flag-router'


### PR DESCRIPTION
Goal is to add the default Sales Channel and Shipping Profile which are currently causing errors in the admin due to the
`default_sales_channel` being `null`.

Both Sales Channel and Shipping Profile will be tied to a `store_id` so that other tenants don't see incorrect Sales Channel /
Shipping Profile.

Goal is for the `store_id` to be required, but since `medusa/src/loaders/default.ts` has `createDefault` it makes this difficult.
